### PR TITLE
Fix site vulnerability

### DIFF
--- a/_includes/head/head.html
+++ b/_includes/head/head.html
@@ -52,8 +52,8 @@
   {% endif %}
 
   <!-- jsDelivr CDN -->
-  <link rel="preconnect" href="cdn.jsdelivr.net">
-  <link rel="dns-prefetch" href="cdn.jsdelivr.net">
+  <link rel="preconnect" href="https://cdn.jsdelivr.net">
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
 
   <!-- Bootstrap -->
   <link rel="stylesheet"

--- a/_includes/head/js-selector.html
+++ b/_includes/head/js-selector.html
@@ -38,7 +38,6 @@
     }
   };
   </script>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script type="text/javascript" id="MathJax-script" async
     src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
   </script>

--- a/assets/js/data/swcache.js
+++ b/assets/js/data/swcache.js
@@ -63,8 +63,7 @@ const allowedDomains = [
 
   'fonts.gstatic.com',
   'fonts.googleapis.com',
-  'cdn.jsdelivr.net',
-  'polyfill.io'
+  'cdn.jsdelivr.net'
 ];
 
 /* Requests that include the following path will be banned */


### PR DESCRIPTION
Removed reference to polyfill.io library, which has been compromised with bad code.

Also a slight, unrelated tweak to the header to maximize robustness.